### PR TITLE
Display filename when parsing errors occur. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (options) {
 
 		protagonist.parse(file.contents.toString(), { type: options.type }, function (error, result) {
 			if (error) {
-				return cb(new PluginError('gulp-protagonist', error));
+				return cb(new PluginError('gulp-protagonist', '(' + file.path + ') ' + error.message));
 			}
 
 			try {
@@ -37,7 +37,7 @@ module.exports = function (options) {
 
 				cb();
 			} catch (e) {
-				cb(new PluginError('gulp-protagonist', e));
+				cb(new PluginError('gulp-protagonist', '(' + file.path + ') ' + e.message));
 			}
 		});
 	});


### PR DESCRIPTION
Helpful when streaming a large collection through gulp-protagonist.

I had a few parse errors strewn about many files, and needed to add the filename to chase them down. First tried passing `showStack` to PluginError but didn't get enough information to be helpful.
